### PR TITLE
add include for <memory>

### DIFF
--- a/include/HdfTuple.hh
+++ b/include/HdfTuple.hh
@@ -5,6 +5,7 @@
 
 #include <functional>
 #include <vector>
+#include <memory>
 
 union data_buffer_t
 {


### PR DESCRIPTION
fixes compilation on e.g. CVMFS where std::shared_ptr of type
IVariableFiller was not allowed due to "shared_ptr not a member of
'std'" compilation errors